### PR TITLE
No javadoc needed for simple and builder methods

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -289,6 +289,7 @@
       <property name="minLineCount" value="4"/>
       <property name="allowedAnnotations" value="Override, Test, Given, When, Then, BeforeEach"/>
       <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
+      <property name="ignoreMethodNamesRegex" value="(newBuilder*)|(with*)"/>
     </module>
     <module name="MethodName">
       <message key="name.invalidPattern"

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -286,7 +286,7 @@
     </module>
     <module name="MissingJavadocMethod">
       <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
+      <property name="minLineCount" value="4"/>
       <property name="allowedAnnotations" value="Override, Test, Given, When, Then, BeforeEach"/>
       <property name="tokens" value="METHOD_DEF, ANNOTATION_FIELD_DEF"/>
     </module>


### PR DESCRIPTION
1. Increase the limit of lines for methods that Javadoc is not necessary.
   Since code is open-sourced a simple if-clause can be self-explainable and does not need to be documented
2. Builder methods are quite straightforward and do not need further documentation.